### PR TITLE
Add size gap/lead for code golf

### DIFF
--- a/templates/stats.html
+++ b/templates/stats.html
@@ -208,6 +208,15 @@
           <th>
             Points
           </th>
+          <th>
+            Code Size
+          </th>
+          <th>
+            Gap
+          </th>
+          <th>
+            Lead
+          </th>
         </tr>
       </thead>
       <tr ng-repeat="line in stats" ng-class="{ success : $index < 5 }">
@@ -215,6 +224,9 @@
         <td>{{ line.rank }}</td>
         <td>{{ line.total }}</td>
         <td>{{ line.points }}</td>
+        <td>{{ line.codeSize }}</td>
+        <td>{{ line.gap !== null ? line.gap : "–" }}</td>
+        <td>{{ line.lead !== null ? line.lead : "–" }}</td>
       </tr>
     </table>
   </div>


### PR DESCRIPTION
This PR adds 3 new columns to code golf puzzles: Code Size, Gap and Lead
![screenshot 2017-11-06 11-19-00](https://user-images.githubusercontent.com/5136335/32431463-a7672dec-c2e4-11e7-9f2c-65571888546b.png)

Gap is difference between current and previous rank; lead is difference between current and next rank;
(not sure if captions are clear enough)

Gap N means that the player has to shave off N symbols to catch up with `rank-1` player.
Lead N means that `rank+1` player has to shave off N symbols to catch up with the player.

On the screenshot I'm 2nd in Javascript, both gap and lead are equal to 0. That means that 1st and 3rd ranks are at the same code size.
