### PR TITLE
boss display

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -61,14 +61,13 @@ angular.module('cgstats', ['ui.router'])
   $scope.loading = true;
 
   $http.get(url + '/search?game=' + encodeURIComponent($stateParams.game.trim()) + '&player=' + encodeURIComponent($stateParams.player.trim()) + ($stateParams.countDraws ? ('&countDraws=' + $stateParams.countDraws) : ''))
-
   .then(function (response) {
 
     $scope.fail = false;
     $scope.date = moment().format('HH:mm:ss');
 
-    $scope.sortType = 'rank';
-    $scope.sortReverse = false;
+    $scope.sortType = 'scoreKey';
+    $scope.sortReverse = true;
 
     $scope.player = response.data.player;
     $scope.stats = response.data.stats.stats || response.data.stats;

--- a/templates/stats.html
+++ b/templates/stats.html
@@ -159,6 +159,9 @@
             <div ng-if="line.codingamer.avatar" class="avatar">
               <img ng-src="https://static.codingame.com/servlet/fileservlet?id={{ line.codingamer.avatar }}&format=navigation_avatar" />
             </div>
+            <div ng-if="line.isBoss" class="avatar">
+              <img ng-src="https://static.codingame.com/assets/league_boss_wood.1a96cb17.png" />
+            </div>
             <a ui-sref="app.stats({ game: game, player: line.pseudo })">{{ line.pseudo }}</a>
           </td>
           <td>


### PR DESCRIPTION
If boss appears in the last battles, it is added to the users list before the stats are computed.
Its score is retrieved by downloading a single replay, in which its scores appears.

The only remaining problem is that you cannot retrieve the boss's actual rank in the league.
If you're at the bottom of your league but you faced the boss in one of your match (likely to happen in the first 10 games), the boss will appear in the table. So you could have a leaderboard with players from rank #30 to #50 for instance, and the boss at the top.

Some might find this information useful, I do not.