### PR TITLE
Fix neverending request for games without leagues

### DIFF
--- a/cgstats.js
+++ b/cgstats.js
@@ -491,7 +491,7 @@ function compileStats(data, myIdentifier, users, countDraws) {
 
   var usersArray = _.values(users);
   for (user of usersArray) {
-    user.scoreKey = user.score + user.league.divisionIndex * 100;
+    user.scoreKey = user.score + (user.league ? user.league.divisionIndex * 100 : 0);
   }
 
   var result = {


### PR DESCRIPTION
Current version is unable to load stats for games without leagues (e.g. PR2). This fix simply removes the assumption leagues always exist when sorting.